### PR TITLE
Fix: TextStats ist deprecated

### DIFF
--- a/01_Einfuehrung/10-spaCy_und_Textacy.ipynb
+++ b/01_Einfuehrung/10-spaCy_und_Textacy.ipynb
@@ -105,8 +105,7 @@
    },
    "outputs": [],
    "source": [
-    "import textacy.text_stats\n",
-    "ts = textacy.text_stats.TextStats(td1)"
+    "from textacy import text_stats as ts"
    ]
   },
   {
@@ -117,7 +116,7 @@
    },
    "outputs": [],
    "source": [
-    "ts.n_words, ts.n_syllables, ts.n_chars"
+    "ts.n_words(td1), ts.n_syllables(td1), ts.n_chars(td1)"
    ]
   },
   {
@@ -128,7 +127,7 @@
    },
    "outputs": [],
    "source": [
-    "ts.flesch_kincaid_grade_level, ts.flesch_reading_ease"
+    "ts.flesch_kincaid_grade_level(td1), ts.flesch_reading_ease(td1)"
    ]
   }
  ],


### PR DESCRIPTION
Die `TextStats`-Klasse ist seit textacy Version 0.12 deprecated. Stattdessen wird das `text_stats`-Modul importiert und seine Funktionen direkt aufgerufen.

Neben dem Vermeiden einer Deprecation-Warnung behebt der Fix außerdem einen `AttributeError`, der entsteht, weil `TextStats` in Version 0.13 keine `flesch_kincaid_grade_level`-Methode mehr hat:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[15], [line 1](vscode-notebook-cell:?execution_count=15&line=1)
----> [1](vscode-notebook-cell:?execution_count=15&line=1) ts.flesch_kincaid_grade_level, ts.flesch_reading_ease

AttributeError: 'TextStats' object has no attribute 'flesch_kincaid_grade_level'
```